### PR TITLE
Fix deprecation warning

### DIFF
--- a/manifests/pref.pp
+++ b/manifests/pref.pp
@@ -4,7 +4,7 @@ define firefox::pref(
 ) {
   include firefox
 
-  if is_string($value) {
+  if $value =~ String {
     $quoted_value = inline_template('<%= @value.inspect %>')
   } else {
     $quoted_value = $value


### PR DESCRIPTION
This method is deprecated, please use match expressions with
Stdlib::Compat::String instead. They are described at
https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions