### PR TITLE
Add support for windows

### DIFF
--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -1,0 +1,2 @@
+---
+firefox::package_provider: "chocolatey"

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -1,2 +1,8 @@
 ---
+firefox::config: "C:\\Program Files\\Mozilla Firefox\\browser\\defaults\\preferences\\00-puppet-preferences.js"
+firefox::group: ~
+firefox::owner: ~
+firefox::managed_directories:
+  - "C:\\Program Files\\Mozilla Firefox\\browser\\defaults"
+  - "C:\\Program Files\\Mozilla Firefox\\browser\\defaults\\preferences"
 firefox::package_provider: "chocolatey"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 # @param owner User owning the preferences configuration file
 # @param group Group owning the preferences configuration file
 # @param managed_directories A list of directories to manage
+# @param manage_package Manage the firefox package on the system
 # @param package The name of the firefox package
 # @param package_ensure Value of the ensure parameter of the firefox package
 # @param package_provider Value of the provider parameter of the firefox package
@@ -14,6 +15,7 @@ class firefox (
   Array[Stdlib::Absolutepath] $managed_directories,
   String                      $package,
   Enum['present', 'latest']   $package_ensure,
+  Boolean                     $manage_package   = true,
   Optional[String[1]]         $package_provider = undef,
 ) {
   file { $managed_directories:
@@ -31,8 +33,10 @@ class firefox (
     mode   => '0644',
   }
 
-  package { $package:
-    ensure   => $package_ensure,
-    provider => $package_provider,
+  if $manage_package {
+    package { $package:
+      ensure   => $package_ensure,
+      provider => $package_provider,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,8 +10,8 @@
 # @param package_provider Value of the provider parameter of the firefox package
 class firefox (
   Stdlib::Absolutepath        $config,
-  String                      $owner,
-  String                      $group,
+  Optional[String[1]]         $owner,
+  Optional[String[1]]         $group,
   Array[Stdlib::Absolutepath] $managed_directories,
   String                      $package,
   Enum['present', 'latest']   $package_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 # @param managed_directories A list of directories to manage
 # @param package The name of the firefox package
 # @param package_ensure Value of the ensure parameter of the firefox package
+# @param package_provider Value of the provider parameter of the firefox package
 class firefox (
   Stdlib::Absolutepath        $config,
   String                      $owner,
@@ -13,6 +14,7 @@ class firefox (
   Array[Stdlib::Absolutepath] $managed_directories,
   String                      $package,
   Enum['present', 'latest']   $package_ensure,
+  Optional[String[1]]         $package_provider = undef,
 ) {
   file { $managed_directories:
     ensure => directory,
@@ -30,6 +32,7 @@ class firefox (
   }
 
   package { $package:
-    ensure => $package_ensure,
+    ensure   => $package_ensure,
+    provider => $package_provider,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,12 @@
         "11",
         "12"
       ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "10"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Original PR:
<details>
<summary>Allow using a custom package provider</summary>
This is mostly handy for windows where the default one in bare crap.  So default to chocolatey for windows.
</details>
