### PR TITLE
Rework the way we build the preferences filename

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    chocolatey: "https://github.com/puppetlabs/puppetlabs-chocolatey"
     concat: "https://github.com/puppetlabs/puppetlabs-concat"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,3 +1,3 @@
 ---
-firefox::config: '/usr/share/firefox-esr/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::directory: "/usr/share/firefox-esr"
 firefox::package: 'firefox-esr'

--- a/data/Debian/Neon.yaml
+++ b/data/Debian/Neon.yaml
@@ -1,3 +1,3 @@
 ---
-firefox::config: '/usr/lib/firefox/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::directory: "/usr/lib/firefox"
 firefox::package: firefox

--- a/data/Debian/PureOS.yaml
+++ b/data/Debian/PureOS.yaml
@@ -1,3 +1,3 @@
 ---
-firefox::config: /usr/share/purebrowser/browser/defaults/preferences/00-puppet-preferences.js
+firefox::directory: "/usr/share/purebrowser"
 firefox::package: purebrowser

--- a/data/Debian/Ubuntu.yaml
+++ b/data/Debian/Ubuntu.yaml
@@ -1,3 +1,3 @@
 ---
-firefox::config: '/usr/lib/firefox/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::directory: "/usr/lib/firefox"
 firefox::package: firefox

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,6 +1,6 @@
 ---
-firefox::config: '/usr/local/lib/firefox/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::directory: "/usr/local/lib/firefox"
 firefox::group: 'wheel'
 firefox::managed_directories:
-- '/usr/local/lib/firefox/browser/defaults'
-- '/usr/local/lib/firefox/browser/defaults/preferences'
+- "browser/defaults"
+- "browser/defaults/preferences"

--- a/data/RedHat-x86_64.yaml
+++ b/data/RedHat-x86_64.yaml
@@ -1,2 +1,2 @@
 ---
-firefox::config: '/usr/lib64/firefox/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::directory: "/usr/lib64/firefox"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-firefox::config: '/usr/lib/firefox/browser/defaults/preferences/00-puppet-preferences.js'
+firefox::distribution: "/usr/lib/firefox"
 firefox::group: 'root'
 firefox::owner: 'root'
 firefox::managed_directories: []

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -1,5 +1,5 @@
 ---
-firefox::config: "C:\\Program Files\\Mozilla Firefox\\browser\\defaults\\preferences\\00-puppet-preferences.js"
+firefox::directory: "C:\\Program Files\\Mozilla Firefox"
 firefox::group: ~
 firefox::owner: ~
 firefox::managed_directories:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # @summary Manage the Firefox web browser
 #
-# @param config Path to Firefox's preferences configuration file
+# @param directory Base directory of Firefox's installation
 # @param owner User owning the preferences configuration file
 # @param group Group owning the preferences configuration file
 # @param managed_directories A list of directories to manage
@@ -8,25 +8,27 @@
 # @param package The name of the firefox package
 # @param package_ensure Value of the ensure parameter of the firefox package
 # @param package_provider Value of the provider parameter of the firefox package
+# @param preferences_file Path to Firefox's preferences configuration file
 class firefox (
-  Stdlib::Absolutepath        $config,
+  Stdlib::Absolutepath        $directory,
   Optional[String[1]]         $owner,
   Optional[String[1]]         $group,
-  Array[Stdlib::Absolutepath] $managed_directories,
+  Array[String[1]]            $managed_directories,
   String                      $package,
   Enum['present', 'latest']   $package_ensure,
   Boolean                     $manage_package   = true,
   Optional[String[1]]         $package_provider = undef,
+  Stdlib::Absolutepath        $preferences_file = "${directory}/browser/defaults/preferences/00-puppet-preferences.js",
 ) {
-  file { $managed_directories:
+  file { $managed_directories.map |$d| { "${directory}/${d}" }:
     ensure => directory,
     owner  => $owner,
     group  => $group,
     mode   => '0755',
-    before => Concat[$config],
+    before => Concat[$preferences_file],
   }
 
-  concat { $config:
+  concat { $preferences_file:
     ensure => present,
     owner  => $owner,
     group  => $group,

--- a/manifests/pref.pp
+++ b/manifests/pref.pp
@@ -21,7 +21,7 @@ define firefox::pref (
   }
 
   concat::fragment { $name:
-    target  => $firefox::config,
+    target  => $firefox::preferences_file,
     content => "${function}(\"${name}\", ${quoted_value});\n",
   }
 }

--- a/spec/classes/firefox_spec.rb
+++ b/spec/classes/firefox_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe 'firefox' do
-  let(:facts) do
-    {
-      osfamily: 'FreeBSD',
-      operatingsystem: 'FreeBSD',
-    }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+
+      if os == 'debian-10-x86_64'
+        it { is_expected.to contain_package('firefox-esr') }
+      else
+        it { is_expected.to contain_package('firefox') }
+      end
+    end
   end
-
-  it { is_expected.to compile.with_all_deps }
-
-  it { is_expected.to contain_package('firefox') }
 end

--- a/spec/defines/pref_spec.rb
+++ b/spec/defines/pref_spec.rb
@@ -1,60 +1,61 @@
 require 'spec_helper'
 
 describe 'firefox::pref' do
-  let(:title) { 'an.option.name' }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
 
-  let(:params) do
-    {
-      value: pref_value,
-      locked: pref_locked,
-    }
-  end
-  let(:facts) do
-    {
-      osfamily: 'FreeBSD',
-    }
-  end
+      let(:title) { 'an.option.name' }
 
-  let(:pref_value) { 'value' }
-  let(:pref_locked) { :undef }
-
-  context 'with a boolean value' do
-    let(:pref_value) do
-      true
-    end
-
-    it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", true);\n)) }
-  end
-
-  context 'with a number value' do
-    let(:pref_value) do
-      42
-    end
-
-    it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", 42);\n)) }
-  end
-
-  context 'with a string value' do
-    context 'without quotes' do
-      let(:pref_value) do
-        'a value'
+      let(:params) do
+        {
+          value: pref_value,
+          locked: pref_locked,
+        }
       end
 
-      it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", "a value");\n)) }
-    end
+      let(:pref_value) { 'value' }
+      let(:pref_locked) { :undef }
 
-    context 'with quotes' do
-      let(:pref_value) do
-        %(a 'value' with "quotes")
+      context 'with a boolean value' do
+        let(:pref_value) do
+          true
+        end
+
+        it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", true);\n)) }
       end
 
-      it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", "a 'value' with \\"quotes\\"");\n)) }
+      context 'with a number value' do
+        let(:pref_value) do
+          42
+        end
+
+        it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", 42);\n)) }
+      end
+
+      context 'with a string value' do
+        context 'without quotes' do
+          let(:pref_value) do
+            'a value'
+          end
+
+          it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", "a value");\n)) }
+        end
+
+        context 'with quotes' do
+          let(:pref_value) do
+            %(a 'value' with "quotes")
+          end
+
+          it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(pref("an.option.name", "a 'value' with \\"quotes\\"");\n)) }
+        end
+      end
+
+      context 'locked preferences' do
+        let(:pref_locked) { true }
+
+        it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(lockPref("an.option.name", "value");\n)) }
+      end
     end
-  end
-
-  context 'locked preferences' do
-    let(:pref_locked) { true }
-
-    it { is_expected.to contain_concat__fragment('an.option.name').with(content: %(lockPref("an.option.name", "value");\n)) }
   end
 end


### PR DESCRIPTION
In order to prepare for adding support for policies configuration, add a
`directory` parameter that points to the root directory of firefox.
Rename the `config` parameter to `preferences_file`.

While here, adjust the test suite to improve coverage of supported
operating systems.