### PR TITLE
Require puppetlabs/stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,6 @@ class firefox (
     mode    => '0644',
     content => {
       policies => $policies,
-    }.to_json(),
+    }.stdlib::to_json(),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
- Add support for Puppet 8
- Require puppetlabs/stdlib 9.x
